### PR TITLE
Force SSLv3 for fosdick

### DIFF
--- a/lib/fosdick.rb
+++ b/lib/fosdick.rb
@@ -34,7 +34,9 @@ module Fosdick
     conn = ::Faraday.new(:url => configuration.host) do |faraday|
       faraday.request  :url_encoded             # form-encode POST params
       # faraday.response :logger                  # log requests to STDOUT
-      faraday.adapter  :patron
+      faraday.adapter  :patron do |session|
+        session.ssl_version = 'SSLv3'
+      end
     end
 
     unless configuration.username.nil?


### PR DESCRIPTION
TLS won't work anymore with customerstatus.com because newer TLS
implementations won't connect to servers with TLS. Because it isn't
clear if you can force TLS 1.0 in Faraday or Patron, I will use SSLv3
for the time being.