### PR TITLE
TLS 1.2 endpoint

### DIFF
--- a/lib/fosdick.rb
+++ b/lib/fosdick.rb
@@ -34,9 +34,7 @@ module Fosdick
     conn = ::Faraday.new(:url => configuration.host) do |faraday|
       faraday.request  :url_encoded             # form-encode POST params
       # faraday.response :logger                  # log requests to STDOUT
-      faraday.adapter  :patron do |session|
-        session.ssl_version = 'SSLv3'
-      end
+      faraday.adapter  :patron
     end
 
     unless configuration.username.nil?

--- a/lib/fosdick/configuration.rb
+++ b/lib/fosdick/configuration.rb
@@ -10,6 +10,6 @@ module Fosdick
     attribute :password, String
     attribute :test_mode, Boolean, default: true
 
-    attribute :host, String, default: "https://www.customerstatus.com/fosdickapi/"
+    attribute :host, String, default: "https://cs.fosdickcorp.com/fosdickapi/"
   end
 end

--- a/lib/fosdick/version.rb
+++ b/lib/fosdick/version.rb
@@ -1,3 +1,3 @@
 module Fosdick
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
This uses the newly published TLS 1.2 endpoint for Fosdick