### PR TITLE
Bump Faraday dependency

### DIFF
--- a/fosdick.gemspec
+++ b/fosdick.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.9"
+  spec.add_dependency "faraday", ">= 0.9", "< 2"
   spec.add_dependency "patron", "~> 0.5.0"
   spec.add_dependency "virtus", "~> 1.0.5"
 

--- a/fosdick.gemspec
+++ b/fosdick.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "patron", "~> 0.5.0"
   spec.add_dependency "virtus", "~> 1.0.5"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "guard-rspec", "~> 4.6.4"


### PR DESCRIPTION
Faraday has released a 1.x version and this gem is unnecessarily preventing Faraday from being upgraded to anything above 0.x.x. This change allows Faraday 1.x.x.

Faraday Changelog: https://github.com/lostisland/faraday/blob/master/CHANGELOG.md

To make sure this won't break anything I ran the specs with the latest version of Faraday [faraday 1.0.1 (was 0.17.3)] and they all passed.

FYI: I also removed the bundler development dependency because it was causing issues for me locally and I figured it was fine to drop because bundler is now included by default in recent versions of Ruby (>=  2.6).